### PR TITLE
Exclude test pack from index

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,8 @@ jobs:
 
     environment:
       VIRTUALENV_DIR: "~/virtualenv"
+      # This pack should not be on the index
+      SKIP_INDEX: "true"
 
     steps:
       - checkout


### PR DESCRIPTION
This allows us to use full pack CI in this test pack without actually adding it to the index.
The full pack CI includes testing changes to the `deploy` step.

Depends on StackStorm-Exchange/ci#108
